### PR TITLE
fix: page layout

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -18,7 +18,6 @@ iframe {
 }
 .desc {
   a {
-    margin: 1rem 0;
     display: inline-block;
     vertical-align: middle;
   }

--- a/pages/author/_id.vue
+++ b/pages/author/_id.vue
@@ -18,12 +18,12 @@
         )
       </div>
 
-      <div class="description">
+      <div v-if="showDesc" class="description">
         <h2 class="head">
           作家について
         </h2>
         <!-- eslint-disable-next-line vue/no-v-html -->
-        <p class="desc" v-html="author.desc" />
+        <p class="desc" v-html="desc" />
       </div>
     </header>
 
@@ -32,7 +32,7 @@
         <h2 class="section-title">
           公開中の作品
         </h2>
-        <ul>
+        <ul v-if="Array.isArray(author.work) && author.work.length > 0">
           <li
             v-for="w in author.work"
             :key="w.work_id"
@@ -45,12 +45,13 @@
             </nuxt-link>
           </li>
         </ul>
+        <span v-else>（なし）</span>
       </div>
       <div class="workings">
         <h2 class="section-title">
           作業中の作品
         </h2>
-        <ul>
+        <ul v-if="Array.isArray(author.wip) && author.wip.length > 0">
           <li>
             <span
               v-for="w in author.wip"
@@ -59,6 +60,7 @@
             >{{ w.titleToDisplay }}</span>
           </li>
         </ul>
+        <span v-else>（なし）</span>
       </div>
     </div>
   </section>
@@ -120,8 +122,12 @@ export default Vue.extend({
         return d
       }
     }
+    
+    const desc = (author!.desc || "").trim()
     return {
       author,
+      desc,
+      showDesc: desc.length > 0,
       bornOn: parseDate(author.born_on),
       diedOn: parseDate(author.died_on)
     }
@@ -150,7 +156,7 @@ h1.page-title {
 }
 
 .description {
-  h3.head {
+  .head {
     font-weight: bold;
     font-size: 1.1em;
     margin-bottom: 0.2rem;
@@ -174,6 +180,11 @@ h2.section-title {
     display: block;
     text-decoration: underline;
     margin-bottom: 1rem;
+  }
+  .workings {
+    .title {
+      text-decoration: none;
+    }
   }
 }
 </style>

--- a/pages/book/_id.vue
+++ b/pages/book/_id.vue
@@ -20,7 +20,7 @@
           {{ work.work_note }}
         </p>
         <p v-show="work.note" class="note">
-          {{ work.note | stripHTML }}
+          {{ note }}
         </p>
       </div>
       <div v-show="work.first_appearance" class="first-edition">
@@ -37,12 +37,6 @@ import { Work } from 'types/work'
 export default Vue.extend({
   name: 'Book',
   components: {},
-  filters: {
-    stripHTML (text: string): string {
-      if (!text) { return '' }
-      return text.replace(/<[^>]*>?/gm, '')
-    }
-  },
   validate ({ params }) {
     return /\d+/.test(params.id)
   },
@@ -59,10 +53,13 @@ export default Vue.extend({
       const workHTMLURL = filledAuthorId && downloadHtml ? `https://www.aozora.gr.jp/cards/${filledAuthorId}/files/${downloadHtml.filename}` : undefined
       const w = book.work
 
+      const note = w.note ? w.note.replace(/<[^>]*>?(\n)?/gm, '') : ""
+      const showTexts = (...texts: Array<string | undefined>) => texts.some(str => str && str.length > 0)
       return {
         book,
         work: w,
-        showDescription: w.work_note || w.note || w.first_appearance,
+        note,
+        showDescription: showTexts(w.work_note, note, w.first_appearance),
         workHTMLURL
       }
     } catch (e) {
@@ -101,7 +98,7 @@ h1.page-title {
 
 .description {
   margin-top: 2rem;
-  h3.head {
+  .head {
     font-weight: bold;
     font-size: 1.1em;
     margin-bottom: 0.2rem;

--- a/types/author.d.ts
+++ b/types/author.d.ts
@@ -10,9 +10,10 @@ export interface AuthorWork {
     role: string
   }>
 }
-interface Author {
+export interface Author {
   id: number
   name: string
+  desc?: string
   alt_id: number
   alt_name: string
   name_kana: string


### PR DESCRIPTION
ページのレイアウトを修正
- 作家ページの「作家について」の中にあるリンクのmargin調整
- 表示する作品がない場合に「（なし）」と表示
- 適用されるべきcssが適用されていなかった